### PR TITLE
fixing image broken link and add ouput image in quick start

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -37,8 +37,8 @@ This section discuss about how to install Mata Elang Platform.
 
 - Integration with OpenCTI
   - [OpenCTI Installation](https://docs.opencti.io/latest/deployment/installation/)
-  - [OpenCTI Connector Configuration](Addons/OpenCTI-Connector-Configuration.md)
-- [Report Generator](Addons/Report-Generator-Configuration-and-Installation.md)
+  - [OpenCTI Connector Configuration](/docs/addons/opencti-connector/OpenCTI-Connector-Configuration.md)
+- [Report Generator](/docs/addons/report-generator/Report-Generator-Configuration-and-Installation.md)
 
 
 ## User Manual

--- a/docs/Installation-and-Configuration/Defense-Center-Installation.md
+++ b/docs/Installation-and-Configuration/Defense-Center-Installation.md
@@ -129,3 +129,6 @@ mataelang-schema-registry-1          confluentinc/cp-schema-registry:7.8.0      
 mataelang-sensor-api-1               ghcr.io/mata-elang-stable/sensor-snort-service:latest                "/go/bin/app server …"   sensor-api               11 seconds ago   Up 10 seconds                 0.0.0.0:50051->50051/tcp, :::50051->50051/tcp
 mataelang-sensor-event-stream-op-1   ghcr.io/mata-elang-stable/event-stream-aggr:latest                   "/go/bin/app -v"         sensor-event-stream-op   11 seconds ago   Up 10 seconds
 ```
+
+🔑 You can access dashboard on http://localhost:5601
+![image](../../static/uploads/d143583d02f5f501f135a9c935f97f6e/image.png)

--- a/docs/addons/opencti-connector/OpenCTI-Connector-Configuration.md
+++ b/docs/addons/opencti-connector/OpenCTI-Connector-Configuration.md
@@ -9,7 +9,7 @@ You can install OpenCTI to integrate with Mata Elang by following this official 
 
 :white_check_mark: Defense Center installed.
 
-[Defense Center Installation](../Installation-and-Configuration/Defense-Center-Installation.md).
+[Defense Center Installation](../../Installation-and-Configuration/Defense-Center-Installation.md).
 
 :white_check_mark: OpenCTI installed.
 

--- a/docs/addons/report-generator/Mata-Elang-v2-Report-Generator-Manual.md
+++ b/docs/addons/report-generator/Mata-Elang-v2-Report-Generator-Manual.md
@@ -9,10 +9,10 @@ Here is how you could generate Mata Elang v2 Statistic Report.
 Open your browser and go to [Mata Elang Report Generator](https://report.mataelang.net/dashboard)
 
 ## Insert Your Defense Center's Credential
-![Mata Elang Report Generator Login Page](../static/uploads/f2b14d8688ccc4b8b6e8e193b7159b6d/rg-login-page.png)
+![Mata Elang Report Generator Login Page](../../../static/uploads/f2b14d8688ccc4b8b6e8e193b7159b6d/rg-login-page.png)
 You need to insert your account credential to proceed.
 
 ## Choosing The Report You Want to Save
-![Mata Elang Report Generator Dashboard](../static/uploads/1bbfdf784c04c664047c29092272040e/rg-dashboard.png)
+![Mata Elang Report Generator Dashboard](../../../static/uploads/1bbfdf784c04c664047c29092272040e/rg-dashboard.png)
 
 At your Mata Elang Report Generator Dashboard, you can download and save the report as PDF file. You can find each report's template name, and it's date of creation.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -496,4 +496,5 @@ Using the official Docker repository is recommended to get the latest version an
 
 ## Accessing the Dashboard
 
-After successfully installing the Mata Elang Defense Center, you can access the dashboard by visiting [http://localhost:5601](http://localhost:5601) in your web browser.
+After successfully installing the Mata Elang Defense Center, you can access the dashboard by visiting [http://localhost:5601](http://localhost:5601) in your web browser with username: admin and password: SecurePassword@123.
+![image](../static/uploads/d143583d02f5f501f135a9c935f97f6e/image.png)


### PR DESCRIPTION
This pull request includes several updates to the documentation for the Mata Elang Platform, primarily focusing on improving links and adding visual aids.

### Documentation Updates:

* [`docs/Home.md`](diffhunk://#diff-e9e59dcd73f0a9494c18bab6e6270dcf3c67236fe11faaf4a46222fb1db0cbf4L40-R41): Updated links for OpenCTI Connector Configuration and Report Generator to use the correct paths.
* [`docs/Installation-and-Configuration/Defense-Center-Installation.md`](diffhunk://#diff-fb8cd6484e3883586421102e0b3362c534f307b7369ae33097f87241b6c74e2fR132-R134): Added instructions for accessing the dashboard and included a relevant image.
* [`docs/addons/opencti-connector/OpenCTi-Connector-Configuration.md`](diffhunk://#diff-fc171de7accc5e82ca54681897159f4b746dfbc70a86ff8e794f50b816ea72e6L12-R12): Corrected the link for Defense Center Installation.
* [`docs/addons/report-generator/Mata-Elang-v2-Report-Generator-Manual.md`](diffhunk://#diff-1968a347dde618c909fe04ae0c0c202995aaaf11886670ef47b23470cedd713bL12-R16): Updated image paths for the Report Generator Login Page and Dashboard.
* [`docs/quick-start.md`](diffhunk://#diff-2159ff2ecf187c0d5f4e9b100b86d6ee75db52a9a4a036791638972eecfae453L499-R500): Added login credentials and an image for accessing the dashboard.