### PR TITLE
Update naming structure

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -40,7 +40,7 @@ This section discuss about how to install Mata Elang Platform.
   - [OpenCTI Connector Configuration](/docs/addons/opencti-connector/OpenCTI-Connector-Configuration.md)
 - [Report Generator](/docs/addons/report-generator/Report-Generator-Configuration-and-Installation.md)
 
-
 ## User Manual
+
 - [OpenDashboard Usage Manual](OpenSearch-Dashboard-Manual-Page.md)
-- [Report Generator Usage Manual](User-Management-Report-Generator.md)
+- [Report Generator Usage Manual](addons/report-generator/User-Management-Report-Generator.md)

--- a/docs/addons/opencti-connector/OpenCTI-Connector-Configuration.md
+++ b/docs/addons/opencti-connector/OpenCTI-Connector-Configuration.md
@@ -1,5 +1,5 @@
 ---
-title: OpenCTI Connector
+title: Installation and Configuration
 sidebar_position: 2
 ---
 

--- a/docs/addons/report-generator/Mata-Elang-v2-Report-Generator-Manual.md
+++ b/docs/addons/report-generator/Mata-Elang-v2-Report-Generator-Manual.md
@@ -1,5 +1,5 @@
 ---
-title: Mata Elang v2 Report Generator
+title: Usage
 sidebar_position: 5
 ---
 

--- a/docs/addons/report-generator/Report-Generator-Configuration-and-Installation.md
+++ b/docs/addons/report-generator/Report-Generator-Configuration-and-Installation.md
@@ -1,5 +1,5 @@
 ---
-title: Report Generator
+title: Installation and Configuration
 sidebar_position: 1
 ---
 

--- a/docs/addons/report-generator/User-Management-Report-Generator.md
+++ b/docs/addons/report-generator/User-Management-Report-Generator.md
@@ -7,18 +7,18 @@ Here is how you create a report from Mata Elang v2 using Mata Elang Report Gener
 
 ## Access your report generator service on browser using https://YOUR_IP_ADDRESS:8085.
 
-![image-20](../static/uploads/5428d2e4896102001a2a50cb71d725ad/image-20.png)
+![image-20](../../../static/uploads/5428d2e4896102001a2a50cb71d725ad/image-20.png)
 
 >**NOTE:** If you haven't registered yet, you have to create new account by clicking **Register your account**
 >
->![image](../static/uploads/49e566fc10fdc37ad7bea2ed2a46a88f/image.png)
->![image](../static/uploads/cd10e3b30a07172d0857125de366a939/image.png)
+>![image](../../../static/uploads/49e566fc10fdc37ad7bea2ed2a46a88f/image.png)
+>![image](../../../static/uploads/cd10e3b30a07172d0857125de366a939/image.png)
 >
 >After that, go back to **Login Page** and use your new account as your credential to log into report generator.
 
 ## Search for the report you want to download.
 
-![image-21](../static/uploads/4accafdcc6653cc06fc40a7a59a411d5/image-21.png)
+![image-21](../../../static/uploads/4accafdcc6653cc06fc40a7a59a411d5/image-21.png)
 
 >- To generate latest report, you can click **Generate Report** button. This action will create a new report and you can check the latest report by checking the **Created At** column.
 >- You can download your report by clicking **Download** button.
@@ -26,4 +26,4 @@ Here is how you create a report from Mata Elang v2 using Mata Elang Report Gener
 
 Your downloaded file will be stored on your browser's download path.
 
-![image-22](../static/uploads/1acbd1921b007274b4f8f01d7f57f94f/image-22.png)
+![image-22](../../../static/uploads/1acbd1921b007274b4f8f01d7f57f94f/image-22.png)

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -27,47 +27,6 @@ This project is based on the article: [The Next-Generation NIDS Platform: Cloud-
 }
 ```
 
-## Mata Elang Platform Architecture
-
-```mermaid
----
-config:
-  layout: elk
-  elk:
-    mergeEdges: false
-    nodePlacementStrategy: SIMPLE 
----
-graph LR
-    network_isp(Internet)
-    network_router(Router)
-    network_tapper(Tapper)
-
-    sensor1_snort(Snort v3)
-    sensor1_parser(Sensor Parser)
-
-    dc_sensor_api(Sensor API Server)
-    dc_kafka(Apache Kafka)
-    dc_opensearch(OpenSearch)
-    dc_dashboard(OpenSearch Dashboard)
-
-    subgraph Site A
-        network_isp-->network_tapper
-        network_tapper-->network_router
-        network_tapper-->sensor1_snort
-        
-        subgraph me_sensor1[Mata Elang Sensor]
-            sensor1_snort-->sensor1_parser
-        end
-    end
-
-    subgraph me_dc[Mata Elang Defense Center]
-        sensor1_parser-->dc_sensor_api
-        dc_sensor_api-->dc_kafka
-        dc_kafka-->dc_opensearch
-        dc_opensearch-->dc_dashboard
-    end
-```
-
 ## Installation
 
 Here, as an example, we will show you how to set up the Mata Elang Platform.
@@ -98,7 +57,6 @@ This section provides information on how to operate and maintain the Mata Elang 
 
 - [Abstract](#abstract)
 - [Project Overview](#project-overview)
-- [Mata Elang Platform Architecture](#mata-elang-platform-architecture)
 - [Installation](#installation)
   - [Sensor Installation and Configuration](#sensor-installation-and-configuration)
   - [Defense Center Installation and Configuration](#defense-center-installation-and-configuration)


### PR DESCRIPTION
This pull request includes several changes to the documentation files to improve clarity and organization. The most important changes include renaming titles for better understanding, updating file paths for images, and removing outdated sections.

Title and content updates:

* [`docs/addons/opencti-connector/OpenCTI-Connector-Configuration.md`](diffhunk://#diff-fc171de7accc5e82ca54681897159f4b746dfbc70a86ff8e794f50b816ea72e6L2-R2): Changed the title from "OpenCTI Connector" to "Installation and Configuration" to better reflect the content.
* [`docs/addons/report-generator/Mata-Elang-v2-Report-Generator-Manual.md`](diffhunk://#diff-1968a347dde618c909fe04ae0c0c202995aaaf11886670ef47b23470cedd713bL2-R2): Changed the title from "Mata Elang v2 Report Generator" to "Usage" to provide a clearer description.
* [`docs/addons/report-generator/Report-Generator-Configuration-and-Installation.md`](diffhunk://#diff-584ebb0deb87334440c02c1abcd4498540562c232842ec8caf4a4d77d563751eL2-R2): Changed the title from "Report Generator" to "Installation and Configuration" to align with the content.

File path updates:

* [`docs/addons/report-generator/User-Management-Report-Generator.md`](diffhunk://#diff-2e06bb1eedaff20a71747efe81e4a60c21ba29ba7e81e015b16d691b38456f2dL10-R29): Updated image paths to ensure proper rendering by changing relative paths.

Content removal:

* [`docs/intro.md`](diffhunk://#diff-22760d417a52c66f14bee182587d458d0737a616dd14cb09748b4c725fc5809fL30-L70): Removed the "Mata Elang Platform Architecture" section to streamline the document and avoid outdated information. [[1]](diffhunk://#diff-22760d417a52c66f14bee182587d458d0737a616dd14cb09748b4c725fc5809fL30-L70) [[2]](diffhunk://#diff-22760d417a52c66f14bee182587d458d0737a616dd14cb09748b4c725fc5809fL101)