### PR TITLE
feat: add Docker support with Dockerfile and docker-compose configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/.next
+**/.cache
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/charts
+**/docker-compose*
+**/compose.y*ml
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+**/build
+**/dist
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1
+
+ARG NODE_VERSION=22.14.0
+ARG NGINX_VERSION=1.25.2
+
+FROM node:${NODE_VERSION}-alpine as base
+
+# Set working directory for all build stages.
+WORKDIR /usr/src/app
+
+FROM nginx:${NGINX_VERSION}-alpine as webserver
+
+################################################################################
+# Create a stage for building the application.
+FROM base as build
+
+# Download additional development dependencies before building, as some projects require
+# "devDependencies" to be installed to build. If you don't need this, remove this step.
+RUN --mount=type=bind,source=package.json,target=package.json \
+    --mount=type=bind,source=yarn.lock,target=yarn.lock \
+    --mount=type=cache,target=/root/.yarn \
+    yarn install --frozen-lockfile
+
+# Copy the rest of the source files into the image.
+COPY . .
+# Run the build script.
+RUN yarn run build
+
+FROM webserver as final
+
+# Copy all the files from the build stage into the image.
+COPY --from=build /usr/src/app/build /usr/share/nginx/html
+
+EXPOSE 80

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  server:
+    build:
+      context: .
+    ports:
+      - 8080:80


### PR DESCRIPTION
This pull request introduces a Docker setup for the project, including a `.dockerignore` file, a `Dockerfile`, and a `compose.yaml` configuration. The most important changes include the addition of file and directory exclusions in `.dockerignore`, the creation of a multi-stage `Dockerfile` for building and serving the application, and the setup of a basic Docker Compose configuration.

### Docker setup:

* [`.dockerignore`](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R1-R34): Added exclusions for various files and directories to prevent them from being copied to the Docker container.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R34): Created a multi-stage Dockerfile to build the application using Node.js and serve it using NGINX.

* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR1-R6): Added a Docker Compose configuration to build and run the application, exposing it on port 8080.